### PR TITLE
feat: per-buffer sign toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,8 @@ marks.nvim defines the following highlight groups:
 
 marks.nvim also defines the following commands:
 
-`:MarksToggleSigns` Toggle signs in the buffer
+`:MarksToggleSigns [ buffer]` Toggle signs globally. Also accepts an optional
+  buffer number to toggle signs for that buffer only.
 
 `:MarksListBuf` Fill the location list with all marks in the current buffer.
 

--- a/doc/marks-nvim.txt
+++ b/doc/marks-nvim.txt
@@ -290,9 +290,11 @@ see |sign_define()|.
 
 marks.nvim also defines the following commands:
 
-*:MarksToggleSigns*
+*:MarksToggleSigns* [ buffer]
 
-Toggle signs in the buffer
+Toggle signs for marks and bookmarks. By default, globally toggles signs, but
+also Accepts an optional buffer number argument to toggle signs for that
+buffer only.
 
 *:MarksListBuf*
 

--- a/plugin/marks.vim
+++ b/plugin/marks.vim
@@ -8,7 +8,7 @@ hi default link MarkSignHL Identifier
 hi default link MarkSignNumHL CursorLineNr
 hi default link MarkVirtTextHL Comment
 
-command! MarksToggleSigns lua require'marks'.mark_state:toggle_signs()
+command! -nargs=? MarksToggleSigns silent lua require'marks'.toggle_signs(<args>)
 command! MarksListBuf exe "lua require'marks'.mark_state:buffer_to_loclist()" | lopen
 command! MarksListGlobal exe "lua require'marks'.mark_state:global_to_loclist()" | lopen
 command! MarksListAll exe "lua require'marks'.mark_state:all_to_loclist()" | lopen


### PR DESCRIPTION
Allows for per-buffer and global toggling of signs. WIP. The global toggle will override buffer local sign settings - if a buffer has signs disabled, but you globally toggle signs on, that will turn signs on for that buffer too.

Also allows sign toggles to work with bookmark signs.

closes #21 