### PR TITLE
Fail gracefully if no group mark set

### DIFF
--- a/lua/marks/bookmark.lua
+++ b/lua/marks/bookmark.lua
@@ -233,6 +233,10 @@ function Bookmarks:annotate()
 
   local group_nr = group_under_cursor(self.groups, bufnr, pos)
 
+  if not group_nr then
+    return
+  end
+
   local bookmark = self.groups[group_nr].marks[bufnr][pos[1]]
 
   if not bookmark then


### PR DESCRIPTION
Annotating when no mark of group set resulted in an error message.

Maybe this should result in some message for user?..