### PR TITLE
feat: add bookmark toggling (#90)

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ marks.nvim also provides a list of `<Plug>` mappings for you, in case you want t
 <Plug>(Marks-prev-bookmark)
 <Plug>(Marks-set-bookmark[0-9])
 <Plug>(Marks-delete-bookmark[0-9])
+<Plug>(Marks-toggle-bookmark[0-9])
 <Plug>(Marks-next-bookmark[0-9])
 <Plug>(Marks-prev-bookmark[0-9])
 ```

--- a/doc/marks-nvim.txt
+++ b/doc/marks-nvim.txt
@@ -201,6 +201,7 @@ The following are the available keys of the mapping table (see above as well):
 
   set_bookmark[0-9]      Sets a bookmark from group[0-9].
   delete_bookmark[0-9]   Deletes all bookmarks from group[0-9].
+  toggle_bookmark[0-9]   Toggles a bookmark from group[0-9].
   delete_bookmark        Deletes the bookmark under the cursor.
   next_bookmark          Moves to the next bookmark having the same type as the
                          bookmark under the cursor.
@@ -269,6 +270,7 @@ on the functionality of each mapping):
     <Plug>(Marks-prev-bookmark)
     <Plug>(Marks-set-bookmark[0-9])
     <Plug>(Marks-delete-bookmark[0-9])
+    <Plug>(Marks-toggle-bookmark[0-9])
     <Plug>(Marks-next-bookmark[0-9])
     <Plug>(Marks-prev-bookmark[0-9])
 

--- a/lua/marks/bookmark.lua
+++ b/lua/marks/bookmark.lua
@@ -94,6 +94,24 @@ function Bookmarks:place_mark(group_nr, bufnr)
   end
 end
 
+function Bookmarks:toggle_mark(group_nr, bufnr)
+  bufnr = bufnr or a.nvim_get_current_buf()
+  local group = self.groups[group_nr]
+
+  if not group then
+    self:init(group_nr)
+    group = self.groups[group_nr]
+  end
+
+  local pos = a.nvim_win_get_cursor(0)
+
+  if group.marks[bufnr] and group.marks[bufnr][pos[1]] then
+    self:delete_mark(group_nr)
+  else
+    self:place_mark(group_nr)
+  end
+end
+
 function Bookmarks:delete_mark(group_nr, bufnr, line)
   bufnr = bufnr or a.nvim_get_current_buf()
   line = line or a.nvim_win_get_cursor(0)[1]

--- a/lua/marks/init.lua
+++ b/lua/marks/init.lua
@@ -117,6 +117,7 @@ end
 -- set_group[0-9] functions
 for i=0,9 do
   M["set_bookmark" .. i] = function() M.bookmark_state:place_mark(i) end
+  M["toggle_bookmark" .. i] = function() M.bookmark_state:toggle_mark(i) end
   M["delete_bookmark" .. i] = function() M.bookmark_state:delete_all(i) end
   M["next_bookmark" .. i] = function() M.bookmark_state:next(i) end
   M["prev_bookmark" .. i] = function() M.bookmark_state:prev(i) end

--- a/plugin/marks.vim
+++ b/plugin/marks.vim
@@ -38,6 +38,7 @@ nnoremap <Plug>(Marks-prev-bookmark) <cmd> lua require'marks'.prev_bookmark()<cr
 for i in [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
   exe "nnoremap <Plug>(Marks-set-bookmark"..i..") <cmd> lua require'marks'.set_bookmark"..i.."()<cr>"
   exe "nnoremap <Plug>(Marks-delete-bookmark"..i..") <cmd> lua require'marks'.delete_bookmark"..i.."()<cr>"
+  exe "nnoremap <Plug>(Marks-toggle-bookmark"..i..") <cmd> lua require'marks'.toggle_bookmark"..i.."()<cr>"
   exe "nnoremap <Plug>(Marks-next-bookmark"..i..") <cmd> lua require'marks'.next_bookmark"..i.."()<cr>"
   exe "nnoremap <Plug>(Marks-prev-bookmark"..i..") <cmd> lua require'marks'.prev_bookmark"..i.."()<cr>"
 endfor


### PR DESCRIPTION
This adds `<Plug>(Marks-toggle-bookmark[0-9])` and `toggle_bookmark[0-9]` so that we could create/delete bookmarks with a single key combination (relates to #90) .

I did not add a default mapping for this since I use quite custom keybindings, so not sure what would make sense with defaults.  Maybe you have some suggestions? Or it could be left without a default mapping.