### PR TITLE
keymap: use nvim api for setting keymaps

### DIFF
--- a/lua/marks/init.lua
+++ b/lua/marks/init.lua
@@ -167,7 +167,7 @@ end
 
 local function apply_mappings()
   for cmd, key in pairs(M.mappings) do
-    vim.cmd("nnoremap <silent> "..key.." <cmd>lua require'marks'."..cmd.."()<cr>")
+    vim.api.nvim_set_keymap("n", key, "", { callback = M[cmd], desc = "marks: "..cmd:gsub("_", " ") })
   end
 end
 


### PR DESCRIPTION
This allows setting a reasonable description for each mapping that will render nicely in plugins like which-key.

This is using the older `vim.api.nvim_set_keymap` function in order to retain compatibility with Neovim 0.5, as noted in the readme.  If/when the minimum version were bumped to 0.7, this could be further simplified to:

``` lua
vim.keymap.set("n", key, M[cmd], { desc = "marks: "..cmd:gsub("_", " ")  }) 
```