### PR TITLE
fix: disable display-signs on floating windows

### DIFF
--- a/lua/marks/mark.lua
+++ b/lua/marks/mark.lua
@@ -35,8 +35,10 @@ function Mark:register_mark(mark, line, col, bufnr)
   end
   buffer.placed_marks[mark] = { line = line, col = col, id = -1 }
 
+  local winid = a.nvim_get_current_win()
+  local is_floating = a.nvim_win_get_config(winid).relative ~= ""
   local display_signs = utils.option_nil(self.opt.buf_signs[bufnr], self.opt.signs)
-  if display_signs then
+  if display_signs and not is_floating then
     local id = mark:byte() * 100
     buffer.placed_marks[mark].id = id
     self:add_sign(bufnr, mark, line, id)


### PR DESCRIPTION
The filetype exclusions are not the best way to disable the mark signs on certain windows as the filetype is a property of the buffer, while floating is a property of the window. The same filetype could be displayed differently depending on whether its window is floating or not. I think most users are unlikely to want these in floating windows, so I disabled them entirely. I'd be happy to make this configurable, but I think the default should be that they are not show, as typically the normal editing workflow does not apply to floating windows.

In my case, they appear in LSP hints, which are not intended to hold a cursor. It also makes the content no longer fit in the window.

Fixes: #60

## Screenshots for LSP

### Before
![2023-11-25-17-46-48](https://github.com/chentoast/marks.nvim/assets/11096602/62c145b8-4d26-416e-afd2-0fba1b1694a4)

### After
![2023-11-25-17-46-10](https://github.com/chentoast/marks.nvim/assets/11096602/98ba2b29-3e89-4e25-a5e0-0f29479a7286)

## Screenshots for Nerd Tree
Ignore the line numbers, they are caused by a different plugin.
### Before
![2023-11-25-17-08-44](https://github.com/chentoast/marks.nvim/assets/11096602/3f281bba-c67e-4a1a-8b72-6357082bf019)
### After
![2023-11-25-17-09-23](https://github.com/chentoast/marks.nvim/assets/11096602/70f0ed84-1e31-4b7c-8b30-d59ddc74f758)