### PR TITLE
feat: allow exclude by buftypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ require'marks'.setup {
   sign_priority = { lower=10, upper=15, builtin=8, bookmark=20 },
   -- disables mark tracking for specific filetypes. default {}
   excluded_filetypes = {},
+  -- disables mark tracking for specific buftypes. default {}
+  excluded_buftypes = {},
   -- marks.nvim allows you to configure up to 10 bookmark groups, each with its own
   -- sign/virttext. Bookmarks can be used to group together positions and quickly move
   -- across multiple buffers. default sign is '!@#$%^&*()' (from 0 to 9), and

--- a/doc/marks-nvim.txt
+++ b/doc/marks-nvim.txt
@@ -132,6 +132,14 @@ plugin. The following options are defined:
     display any signs. Setting and moving to marks with ` or ' will still work, but
     movement commands like "m]" or "m[" will not.
 
+  excluded_buftypes: table                         *marks-excluded_buftypes*
+    (default {})
+
+    Which buftypes to ignore. If a buffer with this buftype is opened, then
+    marks.nvim will not track any marks set in this buffer, and will not
+    display any signs. Setting and moving to marks with ` or ' will still work, but
+    movement commands like "m]" or "m[" will not.
+
   bookmark_[0-9]: table                              *marks-bookmark_config*
     (default {})
 

--- a/lua/marks/init.lua
+++ b/lua/marks/init.lua
@@ -12,7 +12,7 @@ function M.set()
   end
 
   if utils.is_valid_mark(input) then
-    if not M.excluded_fts[vim.bo.ft] then
+    if not M.excluded_fts[vim.bo.ft] and not M.excluded_bts[vim.bo.bt] then
       M.mark_state:place_mark_cursor(input)
     end
     vim.cmd("normal! m" .. input)
@@ -20,13 +20,13 @@ function M.set()
 end
 
 function M.set_next()
-  if not M.excluded_fts[vim.bo.ft] then
+  if not M.excluded_fts[vim.bo.ft] and not M.excluded_bts[vim.bo.bt] then
     M.mark_state:place_next_mark_cursor()
   end
 end
 
 function M.toggle()
-  if not M.excluded_fts[vim.bo.ft] then
+  if not M.excluded_fts[vim.bo.ft] and not M.excluded_bts[vim.bo.bt] then
     M.mark_state:toggle_mark_cursor()
   end
 end
@@ -70,7 +70,7 @@ function M.annotate()
 end
 
 function M.refresh(force_reregister)
-  if M.excluded_fts[vim.bo.ft] then
+  if M.excluded_fts[vim.bo.ft] or M.excluded_bts[vim.bo.bt] then
     return
   end
 
@@ -218,6 +218,13 @@ function M.setup(config)
   end
 
   M.excluded_fts = excluded_fts
+
+  local excluded_bts = {}
+  for _, bt in ipairs(config.excluded_buftypes or {}) do
+    excluded_bts[bt] = true
+  end
+
+  M.excluded_bts = excluded_bts
 
   M.bookmark_state.opt.signs = true
   M.bookmark_state.opt.buf_signs = {}


### PR DESCRIPTION
Close https://github.com/chentoast/marks.nvim/issues/72

There are too many file types that need to be ignored, there are file types I ignored:

https://github.com/ofseed/nvim/blob/f3388dd77834c2d361e03296afbf617a86b147a4/lua/plugins/ui/marks.lua#L21-L48

But if we can ignore it by buftypes, that would be much easier, I only need to ignore `nofile` buftype.