### PR TITLE
Add option to disable floating preview window

### DIFF
--- a/lua/marks/init.lua
+++ b/lua/marks/init.lua
@@ -252,6 +252,12 @@ function M.setup(config)
     M.bookmark_state.priority = config.sign_priority
   end
 
+  if config.float ~= nil then
+	M.float = config.float
+  else
+	M.float = true
+  end
+
   local refresh_interval = utils.option_nil(config.refresh_interval, 150)
 
   local timer = vim.loop.new_timer()

--- a/lua/marks/mark.lua
+++ b/lua/marks/mark.lua
@@ -249,15 +249,21 @@ function Mark.preview_mark()
   local width = a.nvim_win_get_width(0)
   local height = a.nvim_win_get_height(0)
 
-  a.nvim_open_win(pos[1], true, {
-      relative = "win",
-      win = 0,
-      width = math.floor(width / 2),
-      height = math.floor(height / 2),
-      col = math.floor(width / 4),
-      row = math.floor(height / 8),
-      border = "single"
-    })
+  if require('marks').float then
+	a.nvim_open_win(pos[1], true, {
+	  relative = "win",
+	  win = 0,
+	  width = math.floor(width / 2),
+	  height = math.floor(height / 2),
+	  col = math.floor(width / 4),
+	  row = math.floor(height / 8),
+	  border = "single"
+	})
+  else
+	vim.cmd.pedit()
+	vim.cmd('silent! wincmd P')
+  end
+
   vim.cmd("normal! `" .. mark)
   vim.cmd("normal! zz")
 end


### PR DESCRIPTION
if `config.float` is set to false in the setup function, we use neovim's built-in 'preview window' (see `:h preview-window`) instead of opening our own floating window.

The floating window is still used by default, but it is now optional.

Using the preview-window fits my style of managing windows and tabpages better.